### PR TITLE
feat: add localPatterns configuration for media uploads in Next.js

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,13 @@ const nextConfig = {
         hostname: 'ibffbzwoucksfljolszp.supabase.co',
       },
     ],
+    // Payload serves uploads at /api/media/... with query params (e.g. ?prefix=media).
+    // Next.js 16 requires an explicit localPatterns entry when the src includes a search string.
+    localPatterns: [
+      {
+        pathname: '/api/media/**',
+      },
+    ],
   },
   trailingSlash: true,
   turbopack: {


### PR DESCRIPTION
- Introduced localPatterns in next.config.mjs to support media uploads at /api/media/**.
- Ensured compatibility with Next.js 16 by specifying explicit patterns for query parameters.